### PR TITLE
Tiny documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     end
     ```
 
-1. Add Google to your Überauth configuration:
+1. Add Shopify to your Überauth configuration:
 
     ```elixir
     config :ueberauth, Ueberauth,


### PR DESCRIPTION
Fairly straightforward – looks like Google was still in the readme. Replaces it with Shopify.
